### PR TITLE
Fix cross compilation

### DIFF
--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -1,6 +1,9 @@
 
 CMAKE = @cmake@
 
+export CC = $(CC)
+export CXX = $(CXX)
+
 XTRA_LIB = crc32c/libcrc32c.a
 
 PKG_LIBS = $(XTRA_LIB)


### PR DESCRIPTION
Turns out we simply need to tell cmake about the compiler we want to use.